### PR TITLE
Selecting a mode based on overlap with a structure or a bounding box

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -18,6 +18,7 @@ parts:
     - file: photonics/examples/bent_waveguide.py
     - file: photonics/examples/vary_width.py
     - file: photonics/examples/vary_wavelength.py
+    - file: photonics/examples/selecting_modes.py
     - file: photonics/examples/fiber_overlap.py
     - file: photonics/examples/metal_heater_phase_shifter.py
     - file: photonics/examples/metal_heater_phase_shifter_transient.py

--- a/docs/photonics/examples/selecting_modes.py
+++ b/docs/photonics/examples/selecting_modes.py
@@ -1,0 +1,275 @@
+# ---
+# jupyter:
+#   jupytext:
+#     custom_cell_magics: kql
+#     formats: py:percent,ipynb
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: env_3.11
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Selecting modes in the mode solver
+
+# Sometimes we have structures where the mode of interest is 
+# not the mode with the highest effective index. There are a few 
+# ways to select modes of interest in femwell
+
+# %% tags=["hide-input"]
+from collections import OrderedDict
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.constants import epsilon_0, speed_of_light
+from scipy.integrate import solve_ivp
+from shapely.geometry import Polygon
+from skfem import Basis, ElementTriP0, Mesh
+from skfem.io import from_meshio
+import scipy.constants
+
+from femwell.mesh import mesh_from_OrderedDict
+from femwell.mode_solver import (
+    calculate_coupling_coefficient,
+    calculate_hfield,
+    calculate_overlap,
+    compute_modes,
+    plot_mode,
+    select_mode_by_overlap
+)
+
+# %% [markdown]
+
+# We will use as an example a system with a Si and a SiN sections.
+# This could happen, for example, in a system where we are trying
+# to heat a SiN waveguide with a Si resistor
+
+
+# %% tags=["remove-stderr", "hide-input"]
+
+w_sim = 6
+h_clad = 2
+h_box = 2
+w_sin = 1
+w_si = 0.4
+gap = 1.0
+h_sin = 0.4
+h_si = 0.22
+
+wavelength = 1.55
+k0 = 2 * np.pi / wavelength
+
+polygons = OrderedDict(
+    sin=Polygon(
+        [
+            (-w_sin - gap / 2, 0),
+            (-w_sin  - gap / 2, h_sin),
+            (-gap / 2, h_sin),
+            (-gap / 2, 0),
+        ]
+    ),
+    si=Polygon(
+        [
+            (w_si + gap / 2, 0),
+            (w_si + gap / 2, h_si),
+            (gap / 2, h_si),
+            (gap / 2, 0),
+        ]
+    ),
+    clad=Polygon(
+        [
+            (-w_sim / 2, 0),
+            (-w_sim / 2, h_clad),
+            (w_sim / 2, h_clad),
+            (w_sim / 2, 0),
+        ]
+    ),
+    box=Polygon(
+        [
+            (-w_sim / 2, 0),
+            (-w_sim / 2, -h_box),
+            (w_sim / 2, -h_box),
+            (w_sim / 2, 0),
+        ]
+    ),
+)
+
+resolutions = dict(
+    sin={"resolution": 0.03, "distance": 1},
+    si={"resolution": 0.03, "distance": 1},
+)
+
+mesh = from_meshio(
+    mesh_from_OrderedDict(polygons, resolutions, filename="mesh.msh", default_resolution_max=0.2)
+)
+mesh.draw().show()
+
+# %%
+
+basis0 = Basis(mesh, ElementTriP0(), intorder=4)
+
+epsilon = basis0.zeros() + 1.444**2
+epsilon[basis0.get_dofs(elements=("si"))] = 3.4777**2
+epsilon[basis0.get_dofs(elements=("sin"))] = 1.973**2
+
+
+# %% [markdown]
+
+# ## 0. Directly using femwell
+
+# If we use `find_modes`, these are the modes we get:
+
+# %% 
+
+# basis0.plot(epsilon, colorbar=True).show()
+lams, basis, xs = compute_modes(
+    basis0, epsilon, wavelength=wavelength, mu_r=1, num_modes=4
+)
+
+
+plot_mode(basis, np.real(xs[0]), direction="x")
+plt.show()
+plot_mode(basis, np.real(xs[1]), direction="x")
+plt.show()
+plot_mode(basis, np.real(xs[2]), direction="x")
+plt.show()
+plot_mode(basis, np.real(xs[3]), direction="x")
+plt.show()
+
+print(f'The effective index of the SiN mode is {np.real(lams[2])}')
+
+# %% [markdown]
+
+# We can see how to get the SiN mode (which is the mode of
+# interest for us) we need to go to the third mode found by femwell.
+
+# Are there easier ways to get the SiN modes? Yes!
+
+# %% [markdown]
+
+# ## 1. Hack (not 100% accurate): Erasing the Si waveguide
+
+# One thing we can do to find the SiN mode is to "erase" the Si
+# waveguide, or in other words assign the refractive index of SiO2
+# to the Si waveguide.
+
+# Of course, this is in general not desired, because this way we are
+# missing the effect of the presence of the Si waveguide.
+
+# thi smight not be an issue in this example but there's many
+# examples where this is not an acceptable option.
+
+# %% 
+
+epsilon = basis0.zeros() + 1.444**2
+epsilon[basis0.get_dofs(elements=("si"))] = 1.444**2
+epsilon[basis0.get_dofs(elements=("sin"))] = 1.973**2
+
+lams, basis, xs = compute_modes(
+    basis0, epsilon, wavelength=wavelength, mu_r=1, num_modes=2
+)
+
+
+plot_mode(basis, np.real(xs[0]), direction="x")
+plt.show()
+plot_mode(basis, np.real(xs[1]), direction="x")
+plt.show()
+
+print(f'The effective index of the SiN mode is {np.real(lams[0])}')
+
+# %% [markdown]
+# ## 2. Giving a guess effective index
+
+# We can use the `n_guess` parameter to `compute_modes` to
+# select modes close to that effective index. 
+
+# This is great, but of course we need to know what's that guess
+# effective index. The way to do that would be to use option 1 above
+# and then use that as the n_guess.
+
+# %% 
+epsilon = basis0.zeros() + 1.444**2
+epsilon[basis0.get_dofs(elements=("si"))] = 3.4777**2
+epsilon[basis0.get_dofs(elements=("sin"))] = 1.973**2
+
+lams, basis, xs = compute_modes(
+    basis0, epsilon, wavelength=wavelength, mu_r=1, num_modes=2,
+    n_guess = 1.62
+)
+
+
+plot_mode(basis, np.real(xs[0]), direction="x")
+plt.show()
+plot_mode(basis, np.real(xs[1]), direction="x")
+plt.show()
+
+print(f'The effective index of the SiN mode is {np.real(lams[1])}')
+
+# %% [markdown]
+
+# You can see how using `n_guess` can still give the wrong mode!
+
+# %% [markdown]
+
+# ## 3. Using `select_mode_by_overlap`
+
+# This allows to choose a mode that has the biggest overlap with 
+# a given structure.
+
+# There are two main ways to specify the structure:
+# 1. Using the name of the polygon of interest
+# 2. Giving a square bounding box of coordinates
+
+# You can also give it directly the selection_basis of the
+# are of interest.
+
+# A requirement for using `select_mode_by_overlap` is to
+# calculate the H field of the found modes. 
+
+# %% 
+
+lams, basis, xs = compute_modes(
+    basis0, epsilon, wavelength=wavelength, mu_r=1, num_modes=4
+)
+
+# Calculate H field
+H_modes = list()
+for i, E in enumerate(xs):
+    H_modes.append(
+        calculate_hfield(
+            basis,
+            E,
+            lams[i] * (2 * np.pi / wavelength),
+            omega=2 * np.pi / 1.55 * 
+            scipy.constants.speed_of_light,
+                ))
+
+# Option 1: using an element name
+
+ind_mode = select_mode_by_overlap(basis, xs, H_modes,
+                           bbox = None,
+                           elements_list = "sin",
+                           selection_basis = None)
+
+plot_mode(basis, np.real(xs[ind_mode]), direction="x")
+plt.show()
+
+# Option 1: using bounding box
+
+# Format: [xmin, xmax, ymin, ymax]
+bbox = [-2, 0, 0, 0.4]
+
+ind_mode = select_mode_by_overlap(basis, xs, H_modes,
+                           bbox = bbox,
+                           elements_list = None,
+                           selection_basis = None)
+
+plot_mode(basis, np.real(xs[ind_mode]), direction="x")
+plt.show()
+
+# %%

--- a/docs/photonics/examples/selecting_modes.py
+++ b/docs/photonics/examples/selecting_modes.py
@@ -128,7 +128,7 @@ epsilon[basis0.get_dofs(elements=("sin"))] = 1.973**2
 # %%
 
 # basis0.plot(epsilon, colorbar=True).show()
-lams, basis, xs = compute_modes(basis0, epsilon, wavelength=wavelength, num_modes=4, solver="scipy")
+lams, basis, xs = compute_modes(basis0, epsilon, wavelength=wavelength, num_modes=4)
 
 
 plot_mode(basis, np.real(xs[0]), direction="x")

--- a/docs/photonics/examples/selecting_modes.py
+++ b/docs/photonics/examples/selecting_modes.py
@@ -271,5 +271,3 @@ ind_mode = select_mode_by_overlap(basis, xs, H_modes,
 
 plot_mode(basis, np.real(xs[ind_mode]), direction="x")
 plt.show()
-
-# %%

--- a/femwell/mode_solver.py
+++ b/femwell/mode_solver.py
@@ -22,6 +22,7 @@ from skfem import (
 )
 from skfem.helpers import cross, curl, dot, grad, inner
 from skfem.utils import solver_eigen_scipy
+from utils import create_bbox_basis
 
 
 def compute_modes(
@@ -347,13 +348,7 @@ def select_mode_by_overlap(mode_basis, E_modes, H_modes,
     overlaps = list()
 
     if bbox is not None:
-
-        def sel_fun(x):
-            return (x[0] < bbox[1]) * (x[0] > bbox[0]) * (x[1] > bbox[2]) * (x[1] < bbox[3])
-        
-        selection_basis = Basis(mode_basis.mesh, mode_basis.elem,
-                                elements = lambda x: sel_fun(x)
-                                )
+        selection_basis = create_bbox_basis(mode_basis, bbox)
             
     elif elements_list is not None:
         

--- a/femwell/mode_solver.py
+++ b/femwell/mode_solver.py
@@ -364,7 +364,7 @@ def select_mode_by_overlap(mode_basis, E_modes, H_modes,
     
     ind_max = np.argmax(np.abs(overlaps))
 
-    print(overlaps)
+    #print(overlaps)
 
     return ind_max
     

--- a/femwell/utils.py
+++ b/femwell/utils.py
@@ -10,8 +10,8 @@ if "pyodide" in sys.modules:
 else:
     from scipy.sparse import spmatrix
 
-from skfem.utils import CondensedSystem, bmat
 from skfem import Basis
+from skfem.utils import CondensedSystem, bmat
 
 
 def mpc_symmetric(
@@ -94,21 +94,17 @@ def mpc_symmetric(
         ),
     )
 
-def create_bbox_basis(basis, bbox):
+
+def inside_bbox(bbox):
     """
-    Creates a basis that only contains elements in the
-    given bounding box
+    Creates a selection function that is True for elements in the
+    given bounding box coordinates.
 
     Args:
-        basis: original basis with all the elements
-        bbox: 4 element list with [x_min, x_max, y_min, y_max]
+        bbox: 4 element list with [xmin, ymin, xmax, ymax]
     """
 
     def sel_fun(x):
-            return (x[0] < bbox[1]) * (x[0] > bbox[0]) * (x[1] > bbox[2]) * (x[1] < bbox[3])
-        
-    selection_basis = Basis(basis.mesh, basis.elem,
-                            elements = lambda x: sel_fun(x)
-                            )
-    
-    return selection_basis
+        return (x[0] < bbox[2]) * (x[0] > bbox[0]) * (x[1] > bbox[1]) * (x[1] < bbox[3])
+
+    return sel_fun

--- a/femwell/utils.py
+++ b/femwell/utils.py
@@ -11,6 +11,7 @@ else:
     from scipy.sparse import spmatrix
 
 from skfem.utils import CondensedSystem, bmat
+from skfem import Basis
 
 
 def mpc_symmetric(
@@ -92,3 +93,22 @@ def mpc_symmetric(
             lambda x: np.concatenate((x, T @ x[len(U) :] + g)),
         ),
     )
+
+def create_bbox_basis(basis, bbox):
+    """
+    Creates a basis that only contains elements in the
+    given bounding box
+
+    Args:
+        basis: original basis with all the elements
+        bbox: 4 element list with [x_min, x_max, y_min, y_max]
+    """
+
+    def sel_fun(x):
+            return (x[0] < bbox[1]) * (x[0] > bbox[0]) * (x[1] > bbox[2]) * (x[1] < bbox[3])
+        
+    selection_basis = Basis(basis.mesh, basis.elem,
+                            elements = lambda x: sel_fun(x)
+                            )
+    
+    return selection_basis


### PR DESCRIPTION
Partially addresses #32 by allowing selecting a mode out of a list of modes based on an overlap with a structure or bounding box