### PR TITLE
Intensity calculation and plotting

### DIFF
--- a/docs/photonics/examples/waveguide_modes.py
+++ b/docs/photonics/examples/waveguide_modes.py
@@ -85,14 +85,24 @@ for mode in modes:
     print(f"Effective refractive index: {mode.n_eff:.4f}")
     mode.show(mode.E.real, colorbar=True, direction="x")
 
-powers_in_waveguide = []
-confinement_factors_waveguide = []
+# -
+
+# The electric or magnetic field intensity can be plotted directly from the mode object
+
+# +
+
+modes[0].plot_intensity(field=modes[0].E)
+plt.show()
+
 # -
 
 # Now, let's calculate with the modes:
 # What percentage of the mode is within the core for the calculated modes?
 
 # +
+powers_in_waveguide = []
+confinement_factors_waveguide = []
+
 for mode in modes:
     powers_in_waveguide.append(mode.calculate_power(elements="core"))
     confinement_factors_waveguide.append(mode.calculate_confinement_factor(elements="core"))

--- a/docs/photonics/examples/waveguide_modes.py
+++ b/docs/photonics/examples/waveguide_modes.py
@@ -87,11 +87,15 @@ for mode in modes:
 
 # -
 
-# The electric or magnetic field intensity can be plotted directly from the mode object
-
+# The electric and magnetic field intensity can be plotted directly from the mode object
 # +
 
-modes[0].plot_intensity(field=modes[0].E)
+fig, axs = plt.subplots(2, 1)
+modes[0].plot_intensity(field=modes[0].E, ax=axs[0])
+modes[0].plot_intensity(field=modes[0].H, ax=axs[1])
+axs[0].set_title("Normalized Electric Field Intensity")
+axs[1].set_title("Normalized Magnetic Field Intensity")
+plt.tight_layout()
 plt.show()
 
 # -

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -184,6 +184,33 @@ class Mode:
         self.plot(field=field, **kwargs)
         plt.show()
 
+    def plot_intensity(
+        self, field: NDArray, colorbar: bool = True, normalize: bool = True
+    ) -> Tuple[Figure, NDArray]:
+        """Plots the intensity of a field.
+
+        Args:
+            field (NDArray): Field whose intensity is to be plotted.
+            colorbar (bool, optional): Adds a colorbar to the plot. Defaults to True.
+            normalize (bool, optional): Normalizes the intensity by its maximum value. Defaults to True.
+
+        Returns:
+            Tuple[Figure, NDArray]: Figure and axes of the plot.
+        """
+        intensity, intensity_basis = self.calculate_intensity(field=field)
+        if normalize:
+            intensity = intensity / intensity.max()
+
+        fig, ax = plt.subplots()
+        for subdomain in self.basis.mesh.subdomains.keys() - {"gmsh:bounding_entities"}:
+            self.basis.mesh.restrict(subdomain).draw(ax=ax, boundaries_only=True, color="w")
+        intensity_basis.plot(intensity, ax=ax, cmap="inferno")
+
+        if colorbar:
+            plt.colorbar(ax.collections[-1])
+
+        return fig, ax
+
 
 @dataclass(frozen=True)
 class Modes:

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import List, Tuple
 from matplotlib.figure import Figure
+from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 import numpy as np
 from numpy.typing import NDArray
@@ -151,10 +152,10 @@ class Mode:
 
     def calculate_intensity(self, field: NDArray) -> Tuple[NDArray, Basis]:
         """Calculates the intensity of a field as the sum of the absolute values squared of its components.
-        
-        The electric/magnetic intensity comprises of the relative permittivity/permeability 
-        (respectively) as pointed out in https://doi.org/10.1364/OE.16.016659. 
-        
+
+        The electric/magnetic intensity comprises of the relative permittivity/permeability
+        (respectively) as pointed out in https://doi.org/10.1364/OE.16.016659.
+
         The calculation is performed as follows:
         1) The field is interpolated on the quadrature points with the simulation basis;
         2) The intensity is calculated directly on the quadrature points;
@@ -194,23 +195,32 @@ class Mode:
         plt.show()
 
     def plot_intensity(
-        self, field: NDArray, colorbar: bool = True, normalize: bool = True
-    ) -> Tuple[Figure, NDArray]:
+        self,
+        field: NDArray,
+        ax: Axes = None,
+        colorbar: bool = True,
+        normalize: bool = True,
+    ) -> Tuple[Figure, Axes]:
         """Plots the intensity of a field.
 
         Args:
             field (NDArray): Field whose intensity is to be plotted.
+            ax (Axes, optional): Axes onto which the plot is drawn. Defaults to None.
             colorbar (bool, optional): Adds a colorbar to the plot. Defaults to True.
             normalize (bool, optional): Normalizes the intensity by its maximum value. Defaults to True.
 
         Returns:
-            Tuple[Figure, NDArray]: Figure and axes of the plot.
+            Tuple[Figure, Axes]: Figure and axes of the plot.
         """
         intensity, intensity_basis = self.calculate_intensity(field=field)
         if normalize:
             intensity = intensity / intensity.max()
 
-        fig, ax = plt.subplots()
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = plt.gcf()
+
         for subdomain in self.basis.mesh.subdomains.keys() - {"gmsh:bounding_entities"}:
             self.basis.mesh.restrict(subdomain).draw(ax=ax, boundaries_only=True, color="w")
         intensity_basis.plot(intensity, ax=ax, cmap="inferno")

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -149,6 +149,27 @@ class Mode:
             * 0.5
         )
 
+    def calculate_intensity(self, field: NDArray) -> Tuple[NDArray, Basis]:
+        """Calculates the intensity of a field as the sum of the absolute values squared of its components.
+
+        First, the field is interpolated on the quadrature points with a discontinuous
+        element, then the intensity is calculated directly on the quadrature points.
+
+        Args:
+            field (NDArray): Field whose intensity is to be calculated.
+
+        Returns:
+            NDArray, Basis: Interpolated intensity and plot-ready basis
+        """
+        (et, et_basis), (ez, ez_basis) = self.basis.split(field)
+        plot_basis = et_basis.with_element(ElementVector(ElementDG(ElementTriP1())))
+        et_xy = plot_basis.project(et_basis.interpolate(et), dtype=np.complex128)
+        (et_x, et_x_basis), (et_y, et_y_basis) = plot_basis.split(et_xy)
+        ez2 = et_x_basis.project(ez_basis.interpolate(ez), dtype=np.complex128)
+        intensity = np.abs(et_x) ** 2 + np.abs(et_y) ** 2 + np.abs(ez2) ** 2
+
+        return intensity, et_x_basis
+
     def plot(self, field, plot_vectors=False, colorbar=True, direction="y", title="E"):
         return plot_mode(
             self.basis,

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -1,10 +1,11 @@
 """Waveguide analysis based on https://doi.org/10.1080/02726340290084012."""
 from dataclasses import dataclass
 from functools import cached_property
-from typing import List
-
+from typing import List, Tuple
+from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import numpy as np
+from numpy.typing import NDArray
 import scipy.constants
 import scipy.sparse.linalg
 from numpy.typing import NDArray
@@ -332,7 +333,30 @@ def calculate_energy_current_density(basis, xs):
     return basis_energy, scipy.sparse.linalg.spsolve(b_operator, a_operator)
 
 
-def calculate_overlap(basis_i, E_i, H_i, basis_j, E_j, H_j):
+def calculate_overlap(
+    basis_i: Basis,
+    E_i: np.ndarray,
+    H_i: np.ndarray,
+    basis_j: Basis,
+    E_j: np.ndarray,
+    H_j: np.ndarray,
+) -> np.complex64:
+    """Calculates the fully vectorial overlap between two modes.
+
+    If the modes do not share the basis, interpolation is performed automatically.
+
+    Args:
+        basis_i (Basis): Basis of the first mode
+        E_i (np.ndarray): Electric field of the first mode
+        H_i (np.ndarray): Magnetic field of the first mode
+        basis_j (Basis): Basis of the second mode
+        E_j (np.ndarray): Electric field of the first mode
+        H_j (np.ndarray): Magnetic field of the first mode
+
+    Returns:
+        np.complex64: Complex overlap between the two modes
+    """
+
     @Functional(dtype=np.complex64)
     def overlap(w):
         return cross(np.conj(w["E_i"][0]), w["H_j"][0]) + cross(w["E_j"][0], np.conj(w["H_i"][0]))


### PR DESCRIPTION
Now the electric/magnetic field intensity can be calculated and plotted directly from the Mode class.
The intensity is intended as the sum of the absolute values squared of the components of a field $f$: $I=c (|f_x|^2+|f_y|^2+|f_z|^2)$, where $c$ is the real part of the relative permittivity/permeability for electric/magnetic intensity, respectively. 
The calculated intensity is projected onto a discontinuous element using `ElementDG(ElementTriP1())`.
An example with the electric field intensity has been added to `waveguide_modes`.