### PR TITLE
Boundary conditions->Interface conditions

### DIFF
--- a/docs/math/maxwell.md
+++ b/docs/math/maxwell.md
@@ -96,7 +96,7 @@ $$\begin{aligned}
     \mathbf{\nabla}\times\mathbf{H}\left(\mathbf{r},t\right) &=& \mathbf{J}_{\text{ext}}\left(\mathbf{r},t\right) + \varepsilon \frac{\partial \mathbf{E}\left(\mathbf{r},t\right)} {\partial t} \,.
 \end{aligned}$$
 
-### Piecewise constant materials and boundary conditions
+### Piecewise constant materials and interface conditions
 It is instructive to condsider the well-known case of an interface $I$ between two dielectric materials, which appear in many devices. We assume an interface between two materials called $1$ with dielectric constant $\varepsilon_1$ and $2$ with dielectric constant $\varepsilon_2$. The surface is defined by the normal vector of the interface $\mathbf{n}_{I}$ and there are no external surface charges or currents. For simplicity, we surpress the dependencies $\left(\mathbf{r},t\right)$ here. 
 
 All fields can then be split into the component parallel to the interface (hence perpendicular to the normal vector) and perpendicular to the interface (hence parallel to the normal vector). For example we consider the electric field: Define the normalized field vector $\hat{\mathbf{E}}=\mathbf{E}/E$ we split it into
@@ -128,7 +128,7 @@ $$\mathbf{B}^{\perp}_1 =  \mathbf{B}^{\perp}_2  \quad \Leftrightarrow \quad
 
 In these equations we have used $\mathbf{D}=\varepsilon_0\varepsilon\mathbf{E}$ and $\mathbf{H}=\frac{1}{\mu_0}\mathbf{B} $.
 
-While the calculations can be done with keeping $\varepsilon(\mathbf{r})$, the boundary conditions can give a useful sanity check. They also indicate, that at boundaries a fine grid is required, while at areas of homogeneous materials larger grid can be chosen. 
+While the calculations can be done with keeping $\varepsilon(\mathbf{r})$, the interface conditions can give a useful sanity check. They also indicate, that at interfaces a fine grid is required, while at areas of homogeneous materials larger grid can be chosen. 
 
 
 ## Eigenvectors propagating in $x_3$-direction


### PR DESCRIPTION
The term boundary conditions should be used for the outer boundaries of the simulation domain.
Interface conditions describe the continuity between neighboring elements.

See last section in https://en.wikipedia.org/wiki/Interface_conditions_for_electromagnetic_fields

@DorisReiter could you have a look?