### PR TITLE
Fixed typos

### DIFF
--- a/docs/photonics/examples/leaky_waveguide.py
+++ b/docs/photonics/examples/leaky_waveguide.py
@@ -71,7 +71,7 @@ plot_domains(mesh)
 plt.show()
 
 # %% [markdown]
-# Low we define the epsilon!
+# Now we define the epsilon!
 # We add an PML on the right hand-side by adding an imaginary part to the epsilon.
 
 # %%

--- a/docs/photonics/examples/vary_wavelength.py
+++ b/docs/photonics/examples/vary_wavelength.py
@@ -55,7 +55,7 @@ def n_silicon_dioxide(wavelength):
 
 # -
 
-# Low we define the geometry, we use a box for the core with a height of 500nm and a width of 1000nm.
+# Now we define the geometry, we use a box for the core with a height of 500nm and a width of 1000nm.
 # Everything below the waveguide is defined as the box and the waveguide is surrounded by the clad.
 
 # +


### PR DESCRIPTION
Fixed typo in leaky waveguides example and vary wavelength example