### PR TITLE
Fix cylindrical mode solver (signs + H-field calculations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Something missing? Feel free to open an [issue](https://github.com/HelgeGehring/
 - Niko Savola (Google, Aalto University)
 - Rouven Glauert (Idalab)
 - Markus DeMartini (Google)
+- Lucas Grosjean (Google, Femto-ST Institute)
 
 Happy about every form of contribution -
 pull requests, feature requests, issues, questions, ... :)

--- a/docs/julia/waveguide_bent.jl
+++ b/docs/julia/waveguide_bent.jl
@@ -111,8 +111,12 @@ for radius in radiuss
     τ = CellField(get_face_tag(labels, num_cell_dims(model)), Ω)
     # pml_x = x -> 0.1 * max(0, x[1] - (radius + wg_width / 2 + sim_right))^2
     pml_order = 3
-    pml_x = x -> 1/pml_order * max(0, (x[1] - (radius + wg_width / 2 + sim_right)) / pml_thickness)^pml_order * 5
-    pml_y = x -> 0.
+    pml_x =
+        x ->
+            1 / pml_order *
+            max(0, (x[1] - (radius + wg_width / 2 + sim_right)) / pml_thickness)^pml_order *
+            5
+    pml_y = x -> 0.0
 
     modes = calculate_modes(model, ε ∘ τ, λ = 1.55, order = 1)
     println(n_eff(modes[1]))

--- a/docs/julia/waveguide_bent.jl
+++ b/docs/julia/waveguide_bent.jl
@@ -112,7 +112,7 @@ for radius in radiuss
     # pml_x = x -> 0.1 * max(0, x[1] - (radius + wg_width / 2 + sim_right))^2
     pml_order = 3
     pml_x = x -> 1/pml_order * max(0, (x[1] - (radius + wg_width / 2 + sim_right)) / pml_thickness)^pml_order * 5
-    pml_y = x -> 0.1 * max(0, -x[2] - sim_bottom)^2
+    pml_y = x -> 0.
 
     modes = calculate_modes(model, ε ∘ τ, λ = 1.55, order = 1)
     println(n_eff(modes[1]))

--- a/docs/julia/waveguide_bent.jl
+++ b/docs/julia/waveguide_bent.jl
@@ -92,6 +92,7 @@ radiuss = 1:0.5:5
 wg_width = 0.5
 sim_right = 4
 sim_bottom = 4
+pml_thickness = 3
 neffs = ComplexF64[]
 for radius in radiuss
     write_mesh(
@@ -108,7 +109,9 @@ for radius in radiuss
     ε(tag) = Dict(get_tag_from_name(labels, u) => v for (u, v) in epsilons)[tag]
 
     τ = CellField(get_face_tag(labels, num_cell_dims(model)), Ω)
-    pml_x = x -> 0.1 * max(0, x[1] - (radius + wg_width / 2 + sim_right))^2
+    # pml_x = x -> 0.1 * max(0, x[1] - (radius + wg_width / 2 + sim_right))^2
+    pml_order = 3
+    pml_x = x -> 1/pml_order * max(0, (x[1] - (radius + wg_width / 2 + sim_right)) / pml_thickness)^pml_order * 5
     pml_y = x -> 0.1 * max(0, -x[2] - sim_bottom)^2
 
     modes = calculate_modes(model, ε ∘ τ, λ = 1.55, order = 1)

--- a/docs/julia/waveguide_bent_coupling.jl
+++ b/docs/julia/waveguide_bent_coupling.jl
@@ -84,13 +84,13 @@ function write_mesh(;
         meshwell.polySurface.PolySurface(
             model = model,
             polygons = clip_by_rect(env, -np.inf, -np.inf, np.inf, 0),
-            physical_name = "clad",
+            physical_name = "box",
             mesh_order = 2,
         ),
         meshwell.polySurface.PolySurface(
             model = model,
             polygons = clip_by_rect(env, -np.inf, 0, np.inf, np.inf),
-            physical_name = "box",
+            physical_name = "clad",
             mesh_order = 2,
         ),
     ]

--- a/docs/julia/waveguide_bent_coupling.jl
+++ b/docs/julia/waveguide_bent_coupling.jl
@@ -134,8 +134,15 @@ for radius in radiuss
     τ = CellField(get_face_tag(labels, num_cell_dims(model)), Ω)
     # pml_x = x -> 0.1 * max(0, x[1] - (radius + wg_width / 2 + sim_right))^2
     pml_order = 3
-    pml_x = x -> 1/pml_order * max(0, (x[1] - (radius + wg_width / 2 + distance / 2 + sim_right)) / pml_thickness)^pml_order * 5
-    pml_y = x -> 0.
+    pml_x =
+        x ->
+            1 / pml_order *
+            max(
+                0,
+                (x[1] - (radius + wg_width / 2 + distance / 2 + sim_right)) / pml_thickness,
+            )^pml_order *
+            5
+    pml_y = x -> 0.0
 
 
     epsilons = ["core1" => 3.48^2, "core2" => 3.48^2, "box" => 1.46^2, "clad" => 1.46^2]

--- a/docs/julia/waveguide_bent_coupling.jl
+++ b/docs/julia/waveguide_bent_coupling.jl
@@ -115,6 +115,8 @@ radiuss = 10 # [10.,15.,20.]
 wg_width = 0.55
 sim_right = 1
 sim_bottom = 1
+pml_thickness = 3
+distance = 0.8
 overlaps = Float64[]
 Δneff_cylindrical = Float64[]
 for radius in radiuss
@@ -123,14 +125,16 @@ for radius in radiuss
         wg_width = wg_width,
         sim_right = sim_right,
         sim_bottom = sim_bottom,
-        distance = 0.8,
+        distance = distance,
     )
     model = GmshDiscreteModel("mesh.msh")
     Ω = Triangulation(model)
     labels = get_face_labeling(model)
 
     τ = CellField(get_face_tag(labels, num_cell_dims(model)), Ω)
-    pml_x = x -> 0.1 * max(0, x[1] - (radius + wg_width / 2 + sim_right))^2
+    # pml_x = x -> 0.1 * max(0, x[1] - (radius + wg_width / 2 + sim_right))^2
+    pml_order = 3
+    pml_x = x -> 1/pml_order * max(0, (x[1] - (radius + wg_width / 2 + distance / 2 + sim_right)) / pml_thickness)^pml_order * 5
     pml_y = x -> 0.1 * max(0, -x[2] - sim_bottom)^2
 
 

--- a/docs/julia/waveguide_bent_coupling.jl
+++ b/docs/julia/waveguide_bent_coupling.jl
@@ -135,7 +135,7 @@ for radius in radiuss
     # pml_x = x -> 0.1 * max(0, x[1] - (radius + wg_width / 2 + sim_right))^2
     pml_order = 3
     pml_x = x -> 1/pml_order * max(0, (x[1] - (radius + wg_width / 2 + distance / 2 + sim_right)) / pml_thickness)^pml_order * 5
-    pml_y = x -> 0.1 * max(0, -x[2] - sim_bottom)^2
+    pml_y = x -> 0.
 
 
     epsilons = ["core1" => 3.48^2, "core2" => 3.48^2, "box" => 1.46^2, "clad" => 1.46^2]

--- a/src/Maxwell/Waveguide/Waveguide.jl
+++ b/src/Maxwell/Waveguide/Waveguide.jl
@@ -45,7 +45,7 @@ end
 function H(mode::Mode)
     if mode.radius == Inf
         -1im / ustrip(μ_0) / ω(mode) * (
-            (1im * mode.k * mode.E[1] - ∇(mode.E[2])) ⋅
+            (1im * mode.k * mode.E[1] + ∇(mode.E[2])) ⋅
             TensorValue([0.0 1.0 0.0; -1.0 0.0 0.0]) +
             curl(mode.E[1]) * VectorValue(0.0, 0.0, 1.0)
         )

--- a/src/Maxwell/Waveguide/Waveguide.jl
+++ b/src/Maxwell/Waveguide/Waveguide.jl
@@ -31,7 +31,7 @@ n_eff(mode::Mode) =
 n_eff_cylidrical(mode::Mode) =
     mode.radius != Inf ? mode.k / mode.k0 : error("Not a cylindrical mode")
 ω(mode::Mode) = mode.k0 * ustrip(c_0)
-frequency(mode::Mode) = 2π * ω(mode)
+frequency(mode::Mode) = ω(mode) / (2π)
 λ(mode::Mode) = 2π / mode.k0
 function E(mode::Mode)
     if mode.radius == Inf

--- a/src/Maxwell/Waveguide/Waveguide.jl
+++ b/src/Maxwell/Waveguide/Waveguide.jl
@@ -69,9 +69,9 @@ function H(mode::Mode)
         d_θ = γ_θ * s_θ / (γ_r * s_r * γ_y * s_y)
 
         pml_operator = (
-              d_r ⋅ TensorValue(1, 0, 0, 0, 0, 0, 0, 0, 0)
-            + d_y ⋅ TensorValue(0, 0, 0, 0, 1, 0, 0, 0, 0)
-            + d_θ ⋅ TensorValue(0, 0, 0, 0, 0, 0, 0, 0, 1)
+            d_r ⋅ TensorValue(1, 0, 0, 0, 0, 0, 0, 0, 0) +
+            d_y ⋅ TensorValue(0, 0, 0, 0, 1, 0, 0, 0, 0) +
+            d_θ ⋅ TensorValue(0, 0, 0, 0, 0, 0, 0, 0, 1)
         )
 
         -1im / ustrip(μ_0) / ω(mode) * pml_operator ⋅ (
@@ -228,7 +228,7 @@ function calculate_modes(
                             order,
                             ε,
                             radius,
-                            (radius == Inf ? nothing : Pml_funcs(pml_f, pml_g))
+                            (radius == Inf ? nothing : Pml_funcs(pml_f, pml_g)),
                         ),
                     ),
                 ),
@@ -236,7 +236,7 @@ function calculate_modes(
             order,
             ε,
             radius,
-            (radius == Inf ? nothing : Pml_funcs(pml_f, pml_g))
+            (radius == Inf ? nothing : Pml_funcs(pml_f, pml_g)),
         ) for (k2, E) in zip(vals, eachcol(vecs))
     ]
 end


### PR DESCRIPTION
The present commit solves the issues associated with the Julia cylindrical mode solver

- Correct the $2\pi$-factor in the defenition of $\omega$ in the mode-solver.
- The signs of the H-fields calculated from the E-fields are corrected for both the cylindrical and non-cylindrical mode solver.
- Julia bend solver examples were updated by considering a 3-order PML (in order to obtain a 2-order PML after derivation of the function as presented in _Jedidi, Rym, and Roger Pierre. "High-order finite-element methods for the computation of bending loss in optical waveguides." Journal of Lightwave Technology 25.9 (2007): 2618-2630._)