### PR TITLE
Implement the Poynting vector calculation

### DIFF
--- a/docs/photonics/examples/effective_area.py
+++ b/docs/photonics/examples/effective_area.py
@@ -97,7 +97,7 @@ for h in h_list:
                 neff_list.append(np.real(mode.n_eff))
                 aeff_list.append(mode.calculate_effective_area())
                 tm_list.append(mode.transversality)
-                p_list.append(mode.poynting)
+                p_list.append(mode.Pz)
                 break
         else:
             print(f"no TM mode found for {width}")
@@ -197,17 +197,17 @@ plt.show()
 w_fig_h = 500
 idx_fig_h = min(range(len(w_list)), key=lambda x: abs(w_list[x] - w_fig_h))
 h_fig_h = 0.7
-basis_fig_h, P_fig_h = p_dict[str(h_fig_h)][idx_fig_h]
+basis_fig_h, Pz_fig_h = p_dict[str(h_fig_h)][idx_fig_h]
 
 # Data figure f
 w_fig_f = 600
 idx_fig_f = min(range(len(w_list)), key=lambda x: abs(w_list[x] - w_fig_f))
 h_fig_f = 0.5
-basis_fig_f, P_fig_f = p_dict[str(h_fig_f)][idx_fig_f]
+basis_fig_f, Pz_fig_f = p_dict[str(h_fig_f)][idx_fig_f]
 
 fig, ax = plt.subplots(1, 2)
 
-basis_fig_h.plot(np.abs(P_fig_h[2]), ax=ax[0], aspect="equal")
+basis_fig_h.plot(np.abs(Pz_fig_h), ax=ax[0], aspect="equal")
 ax[0].set_title(
     f"Poynting vector $S_z$\nfor h = {h_fig_h}μm & w = {w_fig_h}nm\n(Reproduction of Fig.1.h)"
 )
@@ -221,7 +221,7 @@ for subdomain in basis_fig_h.mesh.subdomains.keys() - {"gmsh:bounding_entities"}
         ax=ax[0], boundaries_only=True, color="k", linewidth=1.0
     )
 
-basis_fig_f.plot(np.abs(P_fig_f[2]), ax=ax[1], aspect="equal")
+basis_fig_f.plot(np.abs(Pz_fig_f), ax=ax[1], aspect="equal")
 ax[1].set_title(
     f"Poynting vector $S_z$\nfor h = {h_fig_f}μm & w = {w_fig_f}nm\n(Reproduction of Fig.1.f)"
 )

--- a/docs/photonics/examples/effective_area.py
+++ b/docs/photonics/examples/effective_area.py
@@ -48,10 +48,12 @@ w_list = [x for x in range(250, 700, 100)]
 neff_dict = dict()
 aeff_dict = dict()
 tm_dict = dict()
+p_dict = dict()
 for h in h_list:
     neff_list = []
     aeff_list = []
     tm_list = []
+    p_list = []
     for width in w_list:
         width = width * 1e-3
         nc = shapely.geometry.box(
@@ -95,12 +97,14 @@ for h in h_list:
                 neff_list.append(np.real(mode.n_eff))
                 aeff_list.append(mode.calculate_effective_area())
                 tm_list.append(mode.transversality)
+                p_list.append(mode.calculate_poynting())
                 break
         else:
             print(f"no TM mode found for {width}")
     neff_dict[str(h)] = neff_list
     aeff_dict[str(h)] = aeff_list
     tm_dict[str(h)] = tm_list
+    p_dict[str(h)] = p_list
 # %% [markdown]
 # Plot the result
 
@@ -183,4 +187,45 @@ ax2.yaxis.set_minor_locator(MultipleLocator(0.2))
 ax4.set_ylim(0, 2.8)
 ax4.legend()
 
+plt.show()
+
+# %% [markdown]
+# We can also plot the modes to compare them with the reference article
+
+# %%
+# Data figure h
+w_fig_h = 500
+idx_fig_h = min(range(len(w_list)), key=lambda x: abs(w_list[x] - w_fig_h))
+h_fig_h = 0.7
+basis_fig_h, P_fig_h = p_dict[str(h_fig_h)][idx_fig_h]
+
+# Data figure f
+w_fig_f = 600
+idx_fig_f = min(range(len(w_list)), key=lambda x: abs(w_list[x] - w_fig_f))
+h_fig_f = 0.5
+basis_fig_f, P_fig_f = p_dict[str(h_fig_f)][idx_fig_f]
+
+fig, ax = plt.subplots(1, 2)
+
+basis_fig_h.plot(np.abs(P_fig_h[2]), ax=ax[0], aspect="equal")
+ax[0].set_title(f"Poynting vector $S_z$\nfor h = {h_fig_h}μm & w = {w_fig_h}nm\n(Reproduction of Fig.1.h)")
+ax[0].set_xlim(-w_fig_h*1e-3/2 - 0.1, w_fig_h*1e-3/2 + 0.1)
+ax[0].set_ylim(capital_h - 0.1, capital_h + h_fig_h + 0.1)
+# Turn off the axis wrt to the article figure
+ax[0].axis('off')
+# Add the contour
+for subdomain in basis_fig_h.mesh.subdomains.keys() - {"gmsh:bounding_entities"}:
+    basis_fig_h.mesh.restrict(subdomain).draw(ax=ax[0], boundaries_only=True, color="k", linewidth=1.0)
+
+basis_fig_f.plot(np.abs(P_fig_f[2]), ax=ax[1], aspect="equal")
+ax[1].set_title(f"Poynting vector $S_z$\nfor h = {h_fig_f}μm & w = {w_fig_f}nm\n(Reproduction of Fig.1.f)")
+ax[1].set_xlim(-w_list[idx_fig_f]*1e-3/2 - 0.1, w_list[idx_fig_f]*1e-3/2 + 0.1)
+ax[1].set_ylim(capital_h - 0.1, capital_h + h_fig_f + 0.1)
+# Turn off the axis wrt to the article figure
+ax[1].axis('off')
+# Add the contour
+for subdomain in basis_fig_f.mesh.subdomains.keys() - {"gmsh:bounding_entities"}:
+    basis_fig_f.mesh.restrict(subdomain).draw(ax=ax[1], boundaries_only=True, color="k", linewidth=1.0)
+
+fig.tight_layout()
 plt.show()

--- a/docs/photonics/examples/effective_area.py
+++ b/docs/photonics/examples/effective_area.py
@@ -208,24 +208,32 @@ basis_fig_f, P_fig_f = p_dict[str(h_fig_f)][idx_fig_f]
 fig, ax = plt.subplots(1, 2)
 
 basis_fig_h.plot(np.abs(P_fig_h[2]), ax=ax[0], aspect="equal")
-ax[0].set_title(f"Poynting vector $S_z$\nfor h = {h_fig_h}μm & w = {w_fig_h}nm\n(Reproduction of Fig.1.h)")
-ax[0].set_xlim(-w_fig_h*1e-3/2 - 0.1, w_fig_h*1e-3/2 + 0.1)
+ax[0].set_title(
+    f"Poynting vector $S_z$\nfor h = {h_fig_h}μm & w = {w_fig_h}nm\n(Reproduction of Fig.1.h)"
+)
+ax[0].set_xlim(-w_fig_h * 1e-3 / 2 - 0.1, w_fig_h * 1e-3 / 2 + 0.1)
 ax[0].set_ylim(capital_h - 0.1, capital_h + h_fig_h + 0.1)
 # Turn off the axis wrt to the article figure
-ax[0].axis('off')
+ax[0].axis("off")
 # Add the contour
 for subdomain in basis_fig_h.mesh.subdomains.keys() - {"gmsh:bounding_entities"}:
-    basis_fig_h.mesh.restrict(subdomain).draw(ax=ax[0], boundaries_only=True, color="k", linewidth=1.0)
+    basis_fig_h.mesh.restrict(subdomain).draw(
+        ax=ax[0], boundaries_only=True, color="k", linewidth=1.0
+    )
 
 basis_fig_f.plot(np.abs(P_fig_f[2]), ax=ax[1], aspect="equal")
-ax[1].set_title(f"Poynting vector $S_z$\nfor h = {h_fig_f}μm & w = {w_fig_f}nm\n(Reproduction of Fig.1.f)")
-ax[1].set_xlim(-w_list[idx_fig_f]*1e-3/2 - 0.1, w_list[idx_fig_f]*1e-3/2 + 0.1)
+ax[1].set_title(
+    f"Poynting vector $S_z$\nfor h = {h_fig_f}μm & w = {w_fig_f}nm\n(Reproduction of Fig.1.f)"
+)
+ax[1].set_xlim(-w_list[idx_fig_f] * 1e-3 / 2 - 0.1, w_list[idx_fig_f] * 1e-3 / 2 + 0.1)
 ax[1].set_ylim(capital_h - 0.1, capital_h + h_fig_f + 0.1)
 # Turn off the axis wrt to the article figure
-ax[1].axis('off')
+ax[1].axis("off")
 # Add the contour
 for subdomain in basis_fig_f.mesh.subdomains.keys() - {"gmsh:bounding_entities"}:
-    basis_fig_f.mesh.restrict(subdomain).draw(ax=ax[1], boundaries_only=True, color="k", linewidth=1.0)
+    basis_fig_f.mesh.restrict(subdomain).draw(
+        ax=ax[1], boundaries_only=True, color="k", linewidth=1.0
+    )
 
 fig.tight_layout()
 plt.show()

--- a/docs/photonics/examples/effective_area.py
+++ b/docs/photonics/examples/effective_area.py
@@ -97,7 +97,7 @@ for h in h_list:
                 neff_list.append(np.real(mode.n_eff))
                 aeff_list.append(mode.calculate_effective_area())
                 tm_list.append(mode.transversality)
-                p_list.append(mode.calculate_poynting())
+                p_list.append(mode.poynting)
                 break
         else:
             print(f"no TM mode found for {width}")

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -369,10 +369,7 @@ def compute_modes(
     if order == 1:
         element = ElementTriN1() * ElementTriP1()
     elif order == 2:
-        # element = ElementTriN2() * ElementTriP2()
-        from skfem.element import ElementQuad2
-
-        element = ElementTriN2() * ElementQuad2  # ElementTriP2()
+        element = ElementTriN2() * ElementTriP2()
     else:
         raise AssertionError("Only order 1 and 2 implemented by now.")
 

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -78,8 +78,7 @@ class Mode:
         (Hx, Hy), Hz = self.basis.interpolate(self.H)
 
         # New basis will be the discontinuous variant used by the solved Ez-field
-        (Et, Et_basis), (En, En_basis) = self.basis.split(self.E)
-        poynting_basis = self.basis.with_element(ElementDG(ElementTriP1()))
+        poynting_basis = self.basis.with_element(ElementDG(self.basis.elem.elems[1]))
 
         # Calculation of the Poynting vector
         Px = Ey * Hz - Ez * Hy

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -181,6 +181,9 @@ class Mode:
         # Extraction of the fields
         (Ex, Ey), Ez = self.basis.interpolate(self.E)
         (Hx, Hy), Hz = self.basis.interpolate(self.H)
+
+        # New basis will be the discontinuous variant used by the solved Ez-field
+        (Et, Et_basis), (En, En_basis) = self.basis.split(self.E)
         new_basis = self.basis.with_element(ElementDG(ElementTriP1()))
 
         # Calculation of the Poynting vector
@@ -350,7 +353,9 @@ def compute_modes(
     if order == 1:
         element = ElementTriN1() * ElementTriP1()
     elif order == 2:
-        element = ElementTriN2() * ElementTriP2()
+        # element = ElementTriN2() * ElementTriP2()
+        from skfem.element import ElementQuad2
+        element = ElementTriN2() * ElementQuad2#ElementTriP2()
     else:
         raise AssertionError("Only order 1 and 2 implemented by now.")
 

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -199,7 +199,6 @@ class Mode:
     def calculate_propagation_loss(self, distance):
         return -20 / np.log(10) * self.k0 * np.imag(self.n_eff) * distance
 
-
     def calculate_power(self, elements=None):
         if not elements:
             basis = self.basis
@@ -357,7 +356,8 @@ def compute_modes(
     elif order == 2:
         # element = ElementTriN2() * ElementTriP2()
         from skfem.element import ElementQuad2
-        element = ElementTriN2() * ElementQuad2#ElementTriP2()
+
+        element = ElementTriN2() * ElementQuad2  # ElementTriP2()
     else:
         raise AssertionError("Only order 1 and 2 implemented by now.")
 

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -79,7 +79,7 @@ class Mode:
 
         # New basis will be the discontinuous variant used by the solved Ez-field
         (Et, Et_basis), (En, En_basis) = self.basis.split(self.E)
-        new_basis = self.basis.with_element(ElementDG(ElementTriP1()))
+        poynting_basis = self.basis.with_element(ElementDG(ElementTriP1()))
 
         # Calculation of the Poynting vector
         Px = Ey * Hz - Ez * Hy
@@ -87,11 +87,11 @@ class Mode:
         Pz = Ex * Hy - Ey * Hx
 
         # Projection of the Poynting vector on the new basis
-        Px_proj = new_basis.project(Px, dtype=np.complex64)
-        Py_proj = new_basis.project(Py, dtype=np.complex64)
-        Pz_proj = new_basis.project(Pz, dtype=np.complex64)
+        Px_proj = poynting_basis.project(Px, dtype=np.complex64)
+        Py_proj = poynting_basis.project(Py, dtype=np.complex64)
+        Pz_proj = poynting_basis.project(Pz, dtype=np.complex64)
 
-        return new_basis, np.array([Px_proj, Py_proj, Pz_proj])
+        return poynting_basis, np.array([Px_proj, Py_proj, Pz_proj])
 
     @cached_property
     def te_fraction(self):

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -92,18 +92,15 @@ class Mode:
 
         return poynting_basis, P_proj
 
-    @cached_property
-    def Px(self):
+    def Sx(self):
         basis, _P = self.poynting
         return basis.split_bases()[0], _P[basis.split_indices()[0]]
 
-    @cached_property
-    def Py(self):
+    def Sy(self):
         basis, _P = self.poynting
         return basis.split_bases()[1], _P[basis.split_indices()[1]]
 
-    @cached_property
-    def Pz(self):
+    def Sz(self):
         basis, _P = self.poynting
         return basis.split_bases()[2], _P[basis.split_indices()[2]]
 

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -94,6 +94,21 @@ class Mode:
         return poynting_basis, np.array([Px_proj, Py_proj, Pz_proj])
 
     @cached_property
+    def Px(self):
+        basis, _P = self.poynting
+        return basis, _P[0]
+
+    @cached_property
+    def Py(self):
+        basis, _P = self.poynting
+        return basis, _P[1]
+
+    @cached_property
+    def Pz(self):
+        basis, _P = self.poynting
+        return basis, _P[2]
+
+    @cached_property
     def te_fraction(self):
         """TE-fraction of the mode"""
 

--- a/femwell/maxwell/waveguide.py
+++ b/femwell/maxwell/waveguide.py
@@ -175,6 +175,26 @@ class Mode:
     def calculate_propagation_loss(self, distance):
         return -20 / np.log(10) * self.k0 * np.imag(self.n_eff) * distance
 
+    def calculate_poynting(self):
+        """Poynting vector of the mode"""
+
+        # Extraction of the fields
+        (Ex, Ey), Ez = self.basis.interpolate(self.E)
+        (Hx, Hy), Hz = self.basis.interpolate(self.H)
+        new_basis = self.basis.with_element(ElementDG(ElementTriP1()))
+
+        # Calculation of the Poynting vector
+        Px = Ey * Hz - Ez * Hy
+        Py = Ez * Hx - Ex * Hz
+        Pz = Ex * Hy - Ey * Hx
+
+        # Projection of the Poynting vector on the new basis
+        Px_proj = new_basis.project(Px, dtype=np.complex64)
+        Py_proj = new_basis.project(Py, dtype=np.complex64)
+        Pz_proj = new_basis.project(Pz, dtype=np.complex64)
+
+        return new_basis, np.array([Px_proj, Py_proj, Pz_proj])
+
     def calculate_power(self, elements=None):
         if not elements:
             basis = self.basis


### PR DESCRIPTION
Regarding the issue #106:
- Implement the function `calculate_poynting()` for the class `Mode()` to calculate the Poynting vector of a mode
- Improve the docs by adding the graph Fig.1.h et Fig.1.f from [the article](https://doi.org/10.1364/OL.37.002295) used in the [effective_area example](https://helgegehring.github.io/femwell/photonics/examples/effective_area.html).
![image](https://github.com/HelgeGehring/femwell/assets/18169686/f21ab5b4-3c98-4dab-bb4c-f2894ece599f)
