### PR TITLE
Replace deprecated np.NaN with np.nan

### DIFF
--- a/femwell/visualization.py
+++ b/femwell/visualization.py
@@ -22,7 +22,7 @@ def plot_domains(mesh, ax=None):
     basis0 = Basis(mesh, ElementTriP0())
 
     subdomains = list(mesh.subdomains.keys() - {"gmsh:bounding_entities"})
-    subdomain_colors = basis0.zeros() * np.NaN
+    subdomain_colors = basis0.zeros() * np.nan
     for i, subdomain in enumerate(subdomains):
         subdomain_colors[basis0.get_dofs(elements=subdomain)] = i
 


### PR DESCRIPTION
With the release of Numpy 2.0 the variable np.NaN has been deprecated and cause an exception to rise. In visualization.py there is still one occurrence of this. As [NumPy Migration Guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#numpy-2-migration-guide) suggests np.NaN is replaced by np.nan.
In this ways examples depending on visualization.py such as waveguide_modes.py can run smoothly