### PR TITLE
cpw --> microstrip

### DIFF
--- a/docs/electronics/examples/microstrip_waveguide_vary_gap.py
+++ b/docs/electronics/examples/microstrip_waveguide_vary_gap.py
@@ -12,9 +12,9 @@
 #     name: python3
 # ---
 # %% [markdown]
-# # Coplanar waveguide - vary gap
+# # Microstrip waveguide - vary gap
 
-# In this example we calculate effective epsilon of the coplanar waveguides from {cite}`Jansen1978`
+# In this example we calculate effective epsilon of the microstrip waveguides from {cite}`Jansen1978`
 
 # %% tags=["hide-input"]
 

--- a/docs/electronics/examples/microstrip_waveguide_vary_width.py
+++ b/docs/electronics/examples/microstrip_waveguide_vary_width.py
@@ -12,9 +12,9 @@
 #     name: python3
 # ---
 # %% [markdown]
-# # Coplanar waveguide - vary width
+# # Microstrip waveguide - vary width
 
-# In this example we calculate effective epsilon of the coplanar waveguides from {cite}`Jansen1978`
+# In this example we calculate effective epsilon of the microstrip waveguides from {cite}`Jansen1978`
 
 # %% tags=["hide-input"]
 


### PR DESCRIPTION
Fixed typo: examples consider a microstrip geometry, and so does the references article

![image](https://github.com/user-attachments/assets/86f1f977-f54f-4454-985a-cce0528e8da4)
